### PR TITLE
 Resolved dependency deprecation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,13 @@
 name = "TabularDisplay"
 uuid = "3eeacb1d-13c2-54cc-9b18-30c86af3cadb"
 authors = ["Tom Kwong <tk3369@gmail.com>"]
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
-Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"
+Format = "1fa38f19-a742-5d3f-a2b9-30dd87b9d5f8"
 
 [compat]
-Formatting = "0.4"
+Format = "~1"
 julia = "1"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ randomstr1   randomstr4   randomstr7   randomstr10  randomstr13  randomstr16
 randomstr2   randomstr5   randomstr8   randomstr11  randomstr14               
 randomstr3   randomstr6   randomstr9   randomstr12  randomstr15               
 
-julia> using Formatting
+julia> using Format
 
 julia> foo = generate_formatter("%7.5f")
 (::#5) (generic function with 1 method)

--- a/src/TabularDisplay.jl
+++ b/src/TabularDisplay.jl
@@ -1,6 +1,6 @@
 module TabularDisplay
 
-using Formatting
+using Format
 
 export displaytable
 


### PR DESCRIPTION


Changed dependency from "Formatting" to "Format" to address the following deprecation warning:

│ │ Formatting.jl has been unmaintained for a while, with some serious
│ │ correctness bugs compromising the original purpose of the package. As a result,
│ │ it has been deprecated - consider using an alternative, such as
│ │ Format.jl (https://github.com/JuliaString/Format.jl) or the Printf stdlib directly.
│ │
│ │ If you are not using Formatting.jl as a direct dependency, please consider
│ │ opening an issue on any packages you are using that do use it as a dependency.
│ │ From Julia 1.9 onwards, you can query ]why Formatting to figure out which
│ │ package originally brings it in as a dependency.

All existing module tests passed, and ReadMe was updated with change to Format.jl
